### PR TITLE
Limit language receipt consumption

### DIFF
--- a/Traveller/js/character.js
+++ b/Traveller/js/character.js
@@ -528,13 +528,15 @@ export function createCharacter(roller, species){
                 remarks += "Cannot increase native language except through education.";
             }else{
                 var nativeLanguageLevel = getNativeLanguageLevel();
-                languageReceipts += 1;
+                
                 if(skills[ENUM_SKILLS.Language].Knowledge[language] && skills[ENUM_SKILLS.Language].Knowledge[language] < nativeLanguageLevel){
+                    languageReceipts += 1;
                     skills[ENUM_SKILLS.Language].Knowledge[language] +=1;
                     remarks = "Gained Language(" + language + ")-" + skills[ENUM_SKILLS.Language].Knowledge[language];
                 }else if(skills[ENUM_SKILLS.Language].Knowledge[language] && skills[ENUM_SKILLS.Language].Knowledge[language]>= nativeLanguageLevel){
                     remarks = "Language("+language+") cannot be increased further.";
                 }else{
+                    languageReceipts += 1;
                     skills[ENUM_SKILLS.Language].Knowledge[language] = nativeLanguageLevel-languageReceipts;
                     remarks = "Gained Language(" + language + ")-" + skills[ENUM_SKILLS.Language].Knowledge[language];
                 }


### PR DESCRIPTION
If a language is already at max and can't be increased, don't increment the language receipt counter.

Closes #432